### PR TITLE
Add ability to read a Serializable from String

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "purescript-prelude": "^3.1.0",
     "purescript-maybe": "^3.0.0",
-    "purescript-node-buffer": "^3.0.1"
+    "purescript-node-buffer": "^4.1.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",

--- a/src/Crypto/Simple.js
+++ b/src/Crypto/Simple.js
@@ -122,10 +122,6 @@ exports.bufferToHex = function(buffer) {
   return buffer.toString("hex")
 }
 
-exports.bufferFromHex = function(string) {
-  return Buffer.from(string, "hex")
-}
-
 exports.encodeWith = function(success) {
   return function(failure) {
     return function(encoding) {

--- a/src/Crypto/Simple.js
+++ b/src/Crypto/Simple.js
@@ -122,6 +122,10 @@ exports.bufferToHex = function(buffer) {
   return buffer.toString("hex")
 }
 
+exports.bufferFromHex = function(string) {
+  return Buffer.from(string, "hex")
+}
+
 exports.encodeWith = function(success) {
   return function(failure) {
     return function(encoding) {

--- a/src/Crypto/Simple.purs
+++ b/src/Crypto/Simple.purs
@@ -24,7 +24,6 @@ module Crypto.Simple
   ) where
 
 import Prelude
-
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Unsafe (unsafePerformEff)
 import Data.Maybe (Maybe(..))


### PR DESCRIPTION
Hi!
 
Love this package, but I was bother with the obligation to read a `Serializable` from a `Node.Buffer`. Your module exports utilities to export everything to a `String` (which is the behavior is want), but we can't reverse the process.

The PR is here to provide this ability.

What do you think about it?